### PR TITLE
Update omniscidb CPU and CUDA env files

### DIFF
--- a/conda-envs/omniscidb-cpu-dev.yaml
+++ b/conda-envs/omniscidb-cpu-dev.yaml
@@ -29,7 +29,7 @@ dependencies:
   - libiconv
   - blosc
   - libgdal>=2.3
-  - arrow-cpp=1.0=*cpu
+  - arrow-cpp=2.0=*cpu
   - thrift-cpp=0.13
   - ncurses
   - flex

--- a/conda-envs/omniscidb-dev.yaml
+++ b/conda-envs/omniscidb-dev.yaml
@@ -50,4 +50,4 @@ dependencies:
   - gxx_impl_linux-64=8
   - gxx_linux-64=8
 # when cuda is enabled, install also
-  - nvcc_linux-64
+  - nvcc_linux-64=11.0


### PR DESCRIPTION
This PR updates arrow to 2.0 on omniscidb cpu env and fix nvcc to 11.0 until omniscidb supports cuda 12.